### PR TITLE
Dependabot警告に対応（brace-expansion）

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "micromatch": "^4.0.8",
     "rollup@2.79.2": "2.80.0",
     "minimatch": "^3.1.5",
-    "@babel/runtime": "^7.29.2"
+    "@babel/runtime": "^7.29.2",
+    "brace-expansion": "^1.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,13 +1647,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+"brace-expansion@npm:^1.1.12":
+  version: 1.1.12
+  resolution: "brace-expansion@npm:1.1.12"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
+  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- resolutionsでbrace-expansionを1.1.12に上書きし、ReDoS脆弱性(low)を解消

## Test plan
- [ ] `yarn install` がエラーなく完了すること
- [ ] `yarn build` が成功すること
- [ ] `yarn npm audit --all` で脆弱性が0件であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)